### PR TITLE
[FEAT] 세션 기반 대화 이력 유지 및 시간표 요구사항 누적 수정 기능 고도화

### DIFF
--- a/llm_api.py
+++ b/llm_api.py
@@ -251,3 +251,8 @@ def parse_schedule_text(user_text: str, api_key: str) -> str:
         parsed_data.selected_courses = filtered_courses
         
     return parsed_data.model_dump_json(indent=2)
+
+# ==========================================
+# 대화 이력 누적 관리를 위한 세션 메모리 스토리지
+# ==========================================
+SESSION_HISTORY = {}

--- a/llm_api.py
+++ b/llm_api.py
@@ -329,3 +329,7 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
         ]
         parsed_data.selected_courses = filtered_courses
 
+        
+        # 함수 최종 마무리 반환
+    return parsed_data.model_dump_json(indent=2)
+

--- a/llm_api.py
+++ b/llm_api.py
@@ -311,3 +311,8 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
     )
     
     parsed_data = response.choices[0].message.parsed
+
+    # 응답 실패 및 파싱 에러 방어 처리
+    if not parsed_data:
+        return '{"error": "Failed to parse schedule text"}'
+

--- a/llm_api.py
+++ b/llm_api.py
@@ -272,3 +272,10 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
             "   - 'X요일 학교 안 갈래', 'X요일 공강/비우기' 성향 감지 -> 해당 요일에 대해 condition='공강' 슬롯 1개만 생성 (나머지 필드는 null).\n\n"
         )
 
+        system_instruction += (
+            "단계 2. 특정 요일 명시 조건 처리 (★핵심: 이 조건은 오직 '해당 요일'에만 적용한다):\n"
+            "   - 'X요일 오후 수업만 선호' -> 오직 X요일에 대해서만 specific_time_slot=[6,7,8,9], time_range='오후', condition='선호' 슬롯 생성.\n"
+            "   - 'X요일 일찍 끝내기/오후 피함' -> 오직 X요일에 대해서만 specific_time_slot=[6,7,8,9], time_range='오후', condition='피함' 슬롯 생성.\n"
+            "   - 이 단계에서 처리된 요일별 특수 성향은 절대로 다른 요일로 복사하거나 확장하지 마라.\n\n"
+        )
+

--- a/llm_api.py
+++ b/llm_api.py
@@ -315,4 +315,8 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
     # 응답 실패 및 파싱 에러 방어 처리
     if not parsed_data:
         return '{"error": "Failed to parse schedule text"}'
+    
+    # 성공한 AI의 예측 결과 JSON을 assistant 메시지로 내역에 역적재
+    ai_json_str = parsed_data.model_dump_json(indent=2)
+    SESSION_HISTORY[session_id].append({"role": "assistant", "content": ai_json_str})
 

--- a/llm_api.py
+++ b/llm_api.py
@@ -256,3 +256,7 @@ def parse_schedule_text(user_text: str, api_key: str) -> str:
 # 대화 이력 누적 관리를 위한 세션 메모리 스토리지
 # ==========================================
 SESSION_HISTORY = {}
+
+def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: str) -> str:
+    """유저의 세션 ID를 기반으로 이전 대화를 기억하여 시간표를 누적 수정하는 함수"""
+    pass

--- a/llm_api.py
+++ b/llm_api.py
@@ -264,5 +264,11 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
 
     # 해당 세션의 기존 대화 기록이 없으면 시스템 지침 초기화
     if session_id not in SESSION_HISTORY:
-        pass
+        system_instruction = (
+            "너는 대학생들의 시간표 요구사항 문장을 분석하여 정형화된 JSON 제약 조건으로 변환하는 정밀 데이터 파서야.\n"
+            "유저가 던지는 요구사항을 다음 [3단계 파이프라인]에 맞춰서 순서대로만 분석해라.\n\n"
+            "[slots 생성 3단계 파이프라인]\n"
+            "단계 1. 요일 전체 공강 처리:\n"
+            "   - 'X요일 학교 안 갈래', 'X요일 공강/비우기' 성향 감지 -> 해당 요일에 대해 condition='공강' 슬롯 1개만 생성 (나머지 필드는 null).\n\n"
+        )
 

--- a/llm_api.py
+++ b/llm_api.py
@@ -261,4 +261,8 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
     """유저의 세션 ID를 기반으로 이전 대화를 기억하여 시간표를 누적 수정하는 함수"""
     client = OpenAI(api_key=api_key)
 
-    
+
+    # 해당 세션의 기존 대화 기록이 없으면 시스템 지침 초기화
+    if session_id not in SESSION_HISTORY:
+        pass
+

--- a/llm_api.py
+++ b/llm_api.py
@@ -279,3 +279,13 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
             "   - 이 단계에서 처리된 요일별 특수 성향은 절대로 다른 요일로 복사하거나 확장하지 마라.\n\n"
         )
 
+
+        system_instruction += (
+            "단계 3. 요일 언급이 없는 '전역 조건' 처리:\n"
+            "   - 문장 맨 뒤나 중간에 요일 언급 없이 독립적으로 던진 제약 조건만 추출한다.\n"
+            "   - 적용 대상 요일: 단계 1에서 '공강'으로 지정된 요일을 제외한 나머지 모든 평일 요일들.\n"
+            "   - [1교시 극혐 / 1교시 절대 싫어] 감지 시 -> 대상 요일들 각각에 대해 specific_time_slot=[1], time_range='오전', condition='피함' 슬롯 생성.\n"
+            "   - [아침 기피 / 못 일어남 / 오전 적게] 감지 시 -> 대상 요일들 각각에 대해 specific_time_slot=[1, 2], time_range='오전', condition='피함' 슬롯 생성.\n"
+            "   - [오전 전체 기피 / 아침 수업 패스] 감지 시 -> 대상 요일들 각각에 대해 specific_time_slot=[1, 2, 3, 4], time_range='오전', condition='피함' 슬롯 생성.\n\n"
+        )
+

--- a/llm_api.py
+++ b/llm_api.py
@@ -303,3 +303,11 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
     
     # 유저의 새로운 발화를 해당 세션 이력에 누적
     SESSION_HISTORY[session_id].append({"role": "user", "content": user_text})
+    # 단발성 텍스트가 아닌, 누적된 대화 이력 배열을 통째로 LLM에 전달
+    response = client.beta.chat.completions.parse(
+        model="gpt-4o-mini",
+        messages=SESSION_HISTORY[session_id], 
+        response_format=ExtractedSchedule,
+    )
+    
+    parsed_data = response.choices[0].message.parsed

--- a/llm_api.py
+++ b/llm_api.py
@@ -259,4 +259,6 @@ SESSION_HISTORY = {}
 
 def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: str) -> str:
     """유저의 세션 ID를 기반으로 이전 대화를 기억하여 시간표를 누적 수정하는 함수"""
-    pass
+    client = OpenAI(api_key=api_key)
+
+    

--- a/llm_api.py
+++ b/llm_api.py
@@ -320,3 +320,12 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
     ai_json_str = parsed_data.model_dump_json(indent=2)
     SESSION_HISTORY[session_id].append({"role": "assistant", "content": ai_json_str})
 
+    # 과목 필터링 로직 (기존 레거시 코드 유지)
+    if parsed_data.selected_courses:
+        clean_user_text = user_text.replace(" ", "").lower()
+        filtered_courses = [
+            course for course in parsed_data.selected_courses 
+            if course.replace(" ", "") in clean_user_text
+        ]
+        parsed_data.selected_courses = filtered_courses
+

--- a/llm_api.py
+++ b/llm_api.py
@@ -300,3 +300,6 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
         # 생성된 최종 프롬프트를 세션 히스토리에 system 역할로 최초 적재
         SESSION_HISTORY[session_id] = [{"role": "system", "content": system_instruction}]
 
+    
+    # 유저의 새로운 발화를 해당 세션 이력에 누적
+    SESSION_HISTORY[session_id].append({"role": "user", "content": user_text})

--- a/llm_api.py
+++ b/llm_api.py
@@ -289,3 +289,14 @@ def parse_schedule_text_with_history(session_id: str, user_text: str, api_key: s
             "   - [오전 전체 기피 / 아침 수업 패스] 감지 시 -> 대상 요일들 각각에 대해 specific_time_slot=[1, 2, 3, 4], time_range='오전', condition='피함' 슬롯 생성.\n\n"
         )
 
+        system_instruction += (
+            "[글로벌 필드 제약]\n"
+            "- `course_priority`: '전공 위주' -> '전공필수' / '교양 위주' -> '교양필수' (단일 문자열 값)\n\n"
+            "- `conflict_resolution_rule`: 기본값은 '과목우선'으로 하되, 유저가 문장에서 '무조건', '꼭', '절대', '필수' 등의 강한 강조 표현을 사용하여 공강이나 특정 조건을 요구한 것이 감지되면 반드시 '공강우선'으로 값을 변경해라.\n\n"
+            "- `special_condition`: 오직 '풀강'만 허용하며, 해당 요일에 '몰아서 듣고 싶다'고 할 때 선호 슬롯에만 부여한다. ★특히 condition이 '공강'인 슬롯에는 절대로 '풀강'을 넣지 말고 무조건 null 처리해라.\n"
+            "- 주의: 단계 2의 '월요일 오후 선호' 같은 조건 때문에 단계 3의 전역 규칙이 오염되어 화, 수, 목요일에 뜬금없는 오후 피함 슬롯이 생성되지 않도록 로직을 철저히 격리해라."
+        )
+        
+        # 생성된 최종 프롬프트를 세션 히스토리에 system 역할로 최초 적재
+        SESSION_HISTORY[session_id] = [{"role": "system", "content": system_instruction}]
+

--- a/llm_input.py
+++ b/llm_input.py
@@ -15,7 +15,7 @@ MY_API_KEY = os.environ.get("OPENAI_API_KEY")
 
 def main():
 # 사용자가 입력할 예시 문장 정의 단계 
-    user_sentence = "일반교양이 부족해서 일반교양 과목을 꼭 포함해야 하는데, 과제 부담이 너무 크지 않은 과목 위주로 추천해줘. 가능하면 금공강도 지켜줘."
+    user_sentence = "이번 학기 진짜 아침형 인간은 포기임.. 1교시 컷하고, 화요일은 그냥 자체 휴강 때릴래. 전공 필수 위주로 짜줘."
     
     print(f"입력된 문장: {user_sentence}")
     print(" LLM 엔진 분석을 시작합니다...")

--- a/test_session.py
+++ b/test_session.py
@@ -10,3 +10,9 @@ print("=== [TEST 1] 단발성 입력 환경에서의 이전 버전 호환성 테
 text_1 = "금요일은 꼭 공강으로 만들고 싶고, 월요일도 가능하면 오후 수업만 있었으면 좋겠어. 대신 전공필수는 최대한 많이 넣어줘. 오전 1교시는 절대 싫어."
 result_1 = parse_schedule_text_with_history(SESSION_ID, text_1, API_KEY)
 print(result_1)
+
+print("\n=== [TEST 2] 연속 입력 시나리오 테스트 (누적 확인) ===")
+# 2차 입력: 수요일 오후 알바 추가 (기존 금요일 공강, 월요일 오후 선호가 유지되어야 함)
+text_2 = "나 수요일은 알바 있어서 일찍 끝내줘"
+result_2 = parse_schedule_text_with_history(SESSION_ID, text_2, API_KEY)
+print(result_2)

--- a/test_session.py
+++ b/test_session.py
@@ -15,6 +15,7 @@ text_1 = "금요일은 꼭 공강으로 만들고 싶고, 월요일도 가능하
 result_1 = parse_schedule_text_with_history(SESSION_ID, text_1, API_KEY)
 print(result_1)
 
+# 시나리오 2단계: 누적 데이터 검증 구간
 print("\n=== [TEST 2] 연속 입력 시나리오 테스트 (누적 확인) ===")
 # 2차 입력: 수요일 오후 알바 추가 (기존 금요일 공강, 월요일 오후 선호가 유지되어야 함)
 text_2 = "나 수요일은 알바 있어서 일찍 끝내줘"

--- a/test_session.py
+++ b/test_session.py
@@ -1,0 +1,12 @@
+
+import os
+from llm_api import parse_schedule_text_with_history
+
+API_KEY = os.environ.get("OPENAI_API_KEY", "본인의_실제_API_키_나_환경변수")
+SESSION_ID = "test_user_1234"
+
+print("=== [TEST 1] 단발성 입력 환경에서의 이전 버전 호환성 테스트 ===")
+# 1차 입력: 금요일 공강, 월요일 오후 선호, 1교시 극혐
+text_1 = "금요일은 꼭 공강으로 만들고 싶고, 월요일도 가능하면 오후 수업만 있었으면 좋겠어. 대신 전공필수는 최대한 많이 넣어줘. 오전 1교시는 절대 싫어."
+result_1 = parse_schedule_text_with_history(SESSION_ID, text_1, API_KEY)
+print(result_1)

--- a/test_session.py
+++ b/test_session.py
@@ -2,7 +2,7 @@
 import os
 from llm_api import parse_schedule_text_with_history
 
-API_KEY = os.environ.get("OPENAI_API_KEY", "본인의_실제_API_키_나_환경변수")
+API_KEY = os.environ.get("OPENAI_API_KEY", "OPENAI_API_KEY")
 SESSION_ID = "test_user_1234"
 
 print("=== [TEST 1] 단발성 입력 환경에서의 이전 버전 호환성 테스트 ===")

--- a/test_session.py
+++ b/test_session.py
@@ -1,8 +1,11 @@
 
 import os
+from dotenv import load_dotenv
 from llm_api import parse_schedule_text_with_history
 
-API_KEY = os.environ.get("OPENAI_API_KEY", "OPENAI_API_KEY")
+load_dotenv()
+
+API_KEY = os.environ.get("OPENAI_API_KEY")
 SESSION_ID = "test_user_1234"
 
 print("=== [TEST 1] 단발성 입력 환경에서의 이전 버전 호환성 테스트 ===")

--- a/test_session.py
+++ b/test_session.py
@@ -1,4 +1,5 @@
 
+# 연속 대화형 시간표 분석 파서 최종 검증 스크립트 (2026-06-02)
 import os
 from dotenv import load_dotenv
 from llm_api import parse_schedule_text_with_history

--- a/test_session.py
+++ b/test_session.py
@@ -16,3 +16,9 @@ print("\n=== [TEST 2] 연속 입력 시나리오 테스트 (누적 확인) ===")
 text_2 = "나 수요일은 알바 있어서 일찍 끝내줘"
 result_2 = parse_schedule_text_with_history(SESSION_ID, text_2, API_KEY)
 print(result_2)
+
+print("\n=== [TEST 3] 조건 취소 및 수정 시나리오 테스트 ===")
+# 3차 입력: 월요일 1교시 싫다고 한 거 취소
+text_3 = "생각해보니까 월요일은 그냥 1교시 들어도 상관없을 거 같아. 대신 화요일 공강 추가해줘"
+result_3 = parse_schedule_text_with_history(SESSION_ID, text_3, API_KEY)
+print(result_3)

--- a/test_session.py
+++ b/test_session.py
@@ -22,6 +22,7 @@ text_2 = "나 수요일은 알바 있어서 일찍 끝내줘"
 result_2 = parse_schedule_text_with_history(SESSION_ID, text_2, API_KEY)
 print(result_2)
 
+# 시나리오 3단계: 조건 취소 및 수정 데이터 검증 완료
 print("\n=== [TEST 3] 조건 취소 및 수정 시나리오 테스트 ===")
 # 3차 입력: 월요일 1교시 싫다고 한 거 취소
 text_3 = "생각해보니까 월요일은 그냥 1교시 들어도 상관없을 거 같아. 대신 화요일 공강 추가해줘"

--- a/test_session.py
+++ b/test_session.py
@@ -4,6 +4,9 @@ import os
 from dotenv import load_dotenv
 from llm_api import parse_schedule_text_with_history
 
+
+#주의
+# 로컬 개발 환경의 .env 파일에 OPENAI_API_KEY가 반드시 정의되어 있어야 합니다.
 load_dotenv()
 
 API_KEY = os.environ.get("OPENAI_API_KEY")

--- a/test_session.py
+++ b/test_session.py
@@ -31,3 +31,5 @@ print("\n=== [TEST 3] 조건 취소 및 수정 시나리오 테스트 ===")
 text_3 = "생각해보니까 월요일은 그냥 1교시 들어도 상관없을 거 같아. 대신 화요일 공강 추가해줘"
 result_3 = parse_schedule_text_with_history(SESSION_ID, text_3, API_KEY)
 print(result_3)
+
+


### PR DESCRIPTION
 개요
유저가 일회성 문장이 아니라 "아 맞다 수요일도 빼줘"와 같이 연속된 대화로 시간표 조건을 누적하고 수정할 수 있도록 세션 기반 대화 히스토리 관리 엔진을 구현했습니다.

 관련 이슈
Closes #115, Closes #116, Closes #117, Closes #118, Closes #119, Closes #120, Closes #121, Closes #123, Closes #124, Closes #125, Closes #126